### PR TITLE
feat: add automated star count updates

### DIFF
--- a/.github/workflows/update-stars.yaml
+++ b/.github/workflows/update-stars.yaml
@@ -1,0 +1,48 @@
+name: Update Star Counts
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  update-stars:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@2df16476c6412c0b5958802b4de1e07a5873d8f9 # v2
+        with:
+          deno-version: vx.x.x
+
+      - name: Update star counts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          deno task update-stars
+
+      - name: Check if there are any changes
+        id: verify-diff
+        run: |
+          git diff --quiet typst/ryotaro_kimura.typ || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.verify-diff.outputs.changed == 'true'
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add typst/ryotaro_kimura.typ
+          git commit -m "chore: update star counts [skip ci]" -m "Updated star counts for OSS projects"
+          git push

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
-    "build": "deno run -ERW --allow-run ./scripts/build.ts"
+    "build": "deno run -ERW --allow-run ./scripts/build.ts",
+    "update-stars": "cd typst && deno run -A update-stars.ts"
   },
   "workspace": [
     "./typst/",

--- a/typst/deno.json
+++ b/typst/deno.json
@@ -2,7 +2,8 @@
   "tasks": {
     "typst": "deno run -RE --allow-run npm:typst",
     "dev": "deno task typst watch ./ryotaro_kimura.typ",
-    "compile": "deno task typst compile ./ryotaro_kimura.typ --font-path ./ibm-sans"
+    "compile": "deno task typst compile ./ryotaro_kimura.typ --font-path ./ibm-sans",
+    "update-stars": "deno run -A update-stars.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.13"

--- a/typst/update-stars.ts
+++ b/typst/update-stars.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env deno run -A
+
+interface Project {
+  owner: string;
+  repo: string;
+  name: string;
+}
+
+const projects: Project[] = [
+  // AI Tools
+  { owner: "ryoppippi", repo: "ccusage", name: "ccusage" },
+  { owner: "ryoppippi", repo: "SiteMCP", name: "SiteMCP" },
+  { owner: "ryoppippi", repo: "curxy", name: "curxy" },
+  
+  // Web Development / TypeScript Ecosystem
+  { owner: "ryoppippi", repo: "unplugin-typia", name: "unplugin-typia" },
+  { owner: "ryoppippi", repo: "pkg-to-jsr", name: "pkg-to-jsr" },
+  { owner: "ryoppippi", repo: "mirror-jsr-to-npm", name: "mirror-jsr-to-npm" },
+  { owner: "ryoppippi", repo: "vim-svelte-inspector", name: "vim-svelte-inspector" },
+  { owner: "ryoppippi", repo: "sveltweet", name: "sveltweet" },
+  
+  // Zig
+  { owner: "ryoppippi", repo: "zigcv", name: "zigcv" },
+  { owner: "ryoppippi", repo: "nyancat.zig", name: "nyancat.zig" },
+];
+
+async function fetchStarCount(owner: string, repo: string): Promise<number> {
+  const token = Deno.env.get("GITHUB_TOKEN");
+  const headers: HeadersInit = {
+    "Accept": "application/vnd.github.v3+json",
+  };
+  
+  if (token) {
+    headers["Authorization"] = `token ${token}`;
+  }
+  
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}`,
+    { headers }
+  );
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${owner}/${repo}: ${response.statusText}`);
+  }
+  
+  const data = await response.json();
+  return data.stargazers_count;
+}
+
+function formatStarCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}k`;
+  }
+  return count.toString();
+}
+
+async function updateTypstFile() {
+  const typstPath = "typst/ryotaro_kimura.typ";
+  let content = await Deno.readTextFile(typstPath);
+  let updated = false;
+  
+  for (const project of projects) {
+    try {
+      const starCount = await fetchStarCount(project.owner, project.repo);
+      const formattedCount = formatStarCount(starCount);
+      
+      // Create a regex pattern to match the project's star count
+      const pattern = new RegExp(
+        `(${project.name}:.*?\\(#icon\\("star"\\))([0-9.]+k?)\\)`,
+        "g"
+      );
+      
+      const newContent = content.replace(pattern, `$1${formattedCount})`);
+      
+      if (newContent !== content) {
+        console.log(`✅ Updated ${project.name}: ${formattedCount} stars`);
+        content = newContent;
+        updated = true;
+      } else {
+        console.log(`ℹ️  ${project.name}: ${formattedCount} stars (no change)`);
+      }
+      
+      // Small delay to avoid rate limiting
+      await new Promise(resolve => setTimeout(resolve, 100));
+    } catch (error) {
+      console.error(`❌ Failed to update ${project.name}:`, error.message);
+    }
+  }
+  
+  if (updated) {
+    await Deno.writeTextFile(typstPath, content);
+    console.log("\n✨ Star counts updated successfully!");
+    return true;
+  } else {
+    console.log("\n👍 All star counts are up to date!");
+    return false;
+  }
+}
+
+// Run the update
+if (import.meta.main) {
+  try {
+    const hasChanges = await updateTypstFile();
+    Deno.exit(hasChanges ? 0 : 0);
+  } catch (error) {
+    console.error("Error:", error);
+    Deno.exit(1);
+  }
+}

--- a/typst/update-stars.ts
+++ b/typst/update-stars.ts
@@ -55,7 +55,7 @@ function formatStarCount(count: number): string {
 }
 
 async function updateTypstFile() {
-  const typstPath = "typst/ryotaro_kimura.typ";
+  const typstPath = "ryotaro_kimura.typ";
   let content = await Deno.readTextFile(typstPath);
   let updated = false;
   


### PR DESCRIPTION
## Summary
- Added Deno script to fetch GitHub star counts for OSS projects
- Created GitHub Actions workflow to run daily and update star counts
- Configured automatic commits when star counts change

## Implementation Details
- Script located in `typst/update-stars.ts` fetches star counts from GitHub API
- Supports GitHub token for higher rate limits
- Formats counts (e.g., 2.1k for 2100+ stars)
- Updates `typst/ryotaro_kimura.typ` file in-place
- GitHub Actions workflow runs daily at 00:00 UTC
- Commits changes automatically with [skip ci] tag

## Test plan
- [x] Test script locally with `deno task update-stars`
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Confirm automatic commits work as expected