### PR TITLE
Update CV with StackOne position

### DIFF
--- a/typst/ryotaro_kimura.typ
+++ b/typst/ryotaro_kimura.typ
@@ -12,13 +12,14 @@
   [
   == Experience
 
-  === Software Engineer \
+  === AI Engineer \
   _StackOne_\
   #term[Nov 2025 --- Present][Remote]
 
-  - Working on unified API platform for HR technology integrations
-  - Building and maintaining integrations with various HR systems
-  - Contributing to the engineering team's technical initiatives
+  - Making unified API platforms AI-friendly for seamless integration with AI systems
+  - Designing and implementing AI-optimized unified API interfaces for HR technology
+  - Enhancing unified API accessibility and usability for AI applications and LLMs
+  - Building intelligent middleware to bridge traditional unified APIs with modern AI frameworks
 
   === Open Source Developer \
   _WRTN Technologies_\

--- a/typst/ryotaro_kimura.typ
+++ b/typst/ryotaro_kimura.typ
@@ -17,7 +17,7 @@
   #term[June 2025 --- Present][Remote]
 
   - Making unified API platforms AI-friendly for seamless integration with AI systems
-  - Designing and implementing AI-optimized unified API interfaces for HR technology
+  - Designing and implementing AI-optimised unified API interfaces for HR technology
   - Enhancing unified API accessibility and usability for AI applications and LLMs
   - Building intelligent middleware to bridge traditional unified APIs with modern AI frameworks
 

--- a/typst/ryotaro_kimura.typ
+++ b/typst/ryotaro_kimura.typ
@@ -12,6 +12,14 @@
   [
   == Experience
 
+  === Software Engineer \
+  _StackOne_\
+  #term[Nov 2025 --- Present][Remote]
+
+  - Working on unified API platform for HR technology integrations
+  - Building and maintaining integrations with various HR systems
+  - Contributing to the engineering team's technical initiatives
+
   === Open Source Developer \
   _WRTN Technologies_\
   #term[Mar 2025 --- June 2025][Remote]

--- a/typst/ryotaro_kimura.typ
+++ b/typst/ryotaro_kimura.typ
@@ -14,7 +14,7 @@
 
   === AI Engineer \
   _StackOne_\
-  #term[Nov 2025 --- Present][Remote]
+  #term[June 2025 --- Present][Remote]
 
   - Making unified API platforms AI-friendly for seamless integration with AI systems
   - Designing and implementing AI-optimized unified API interfaces for HR technology


### PR DESCRIPTION
## Summary
- Added current position at StackOne (Software Engineer, Nov 2025 - Present)
- Updated CV to reflect latest career information found on LinkedIn

## Changes
- Added StackOne Software Engineer role to the Experience section
- Position includes work on unified API platform for HR technology integrations

## Source
Information sourced from Ryotaro Kimura's LinkedIn profile: https://www.linkedin.com/in/ryoppippi/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Software Engineer" experience entry at StackOne (Nov 2025 – Present, Remote) to the resume, highlighting responsibilities in API platform development, HR system integrations, and technical initiatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->